### PR TITLE
Fix navbar overlap on several routes

### DIFF
--- a/src/pages/careers/[slug]/index.astro
+++ b/src/pages/careers/[slug]/index.astro
@@ -15,7 +15,7 @@ const { job } = Astro.props;
 ---
 
 <Layout title={`${job.title} | Careers | GC International`}>
-  <section class="py-16 px-6 bg-[#f9f9f9] min-h-screen">
+  <section class="pt-32 pb-16 px-6 bg-[#f9f9f9] min-h-screen">
     <div class="max-w-3xl mx-auto bg-white rounded-lg shadow-md p-8 border border-gray-200 space-y-6">
       <div>
         <h1 class="text-3xl font-bold mb-2">{job.title}</h1>

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -22,7 +22,7 @@ try {
 ---
 
 <Layout title="Application Submitted | GC Careers">
-  <section class="py-20 px-6 text-center bg-[#f5f5f5] min-h-[60vh]">
+  <section class="pt-32 pb-20 px-6 text-center bg-[#f5f5f5] min-h-[60vh]">
     <div class="max-w-xl mx-auto">
       <h1 class="text-3xl font-bold text-green-600 mb-4"> Application Submitted!</h1>
       <p class="text-lg mb-6">

--- a/src/pages/careers/apply/[slug]/index.astro
+++ b/src/pages/careers/apply/[slug]/index.astro
@@ -22,7 +22,7 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
 ---
 
 <Layout title={`Apply | ${job.title} | GC International`}>
-  <section class="py-12 px-4 max-w-3xl mx-auto">
+  <section class="pt-32 pb-12 px-4 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-4">Apply for {job.title}</h1>
 
     <form

--- a/src/pages/careers/apply/[slug]/review.astro
+++ b/src/pages/careers/apply/[slug]/review.astro
@@ -32,7 +32,7 @@ const get = (field: string) => formData.get(field) ?? "";
 ---
 
 <Layout title={`Review | ${job.title} | GC Careers`}>
-  <section class="py-12 px-4 max-w-3xl mx-auto">
+  <section class="pt-32 pb-12 px-4 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-6">
       Review Your Application for <span class="text-blue-800">{job.title}</span>
     </h1>

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -6,7 +6,7 @@ const jobs = await getJobs();
 ---
 
 <Layout title="Careers | GC International">
-  <section class="py-20 px-6 bg-[#f9f9f9] min-h-screen">
+  <section class="pt-32 pb-20 px-6 bg-[#f9f9f9] min-h-screen">
     <div class="max-w-5xl mx-auto">
       <h1 class="text-4xl font-bold mb-10 text-center">Join Our Team</h1>
 

--- a/src/pages/company.astro
+++ b/src/pages/company.astro
@@ -9,8 +9,9 @@ import JoinUsSection from "../components/JoinUsSection";
 ---
 
 <Layout title="Company">
-  <!-- Hero / Image Carousel -->
-  <ImageCarousel client:only="react" />
+  <div class="pt-32">
+    <!-- Hero / Image Carousel -->
+    <ImageCarousel client:only="react" />
 
   <!-- Who We Are Section -->
   <WhoWeAre client:only="react" />
@@ -24,6 +25,7 @@ import JoinUsSection from "../components/JoinUsSection";
   <!-- Become a Partner Section -->
   <BecomePartnerSection client:only="react" />
 
-  <!-- Join Us Section -->
-  <JoinUsSection client:only="react" />
+    <!-- Join Us Section -->
+    <JoinUsSection client:only="react" />
+  </div>
 </Layout>

--- a/src/pages/network.astro
+++ b/src/pages/network.astro
@@ -7,7 +7,7 @@ const locations = await fetchLocations();
 ---
 
 <Layout title="G&C Network Map">
-  <section class="min-h-screen px-4 py-20">
+  <section class="min-h-screen px-4 pt-32 pb-20">
     <h1 class="text-3xl font-bold text-center mb-8">Global Network Map</h1>
     <NetworkMap locations={locations} client:only="react" />
   </section>


### PR DESCRIPTION
## Summary
- add top padding to `/company`
- add top padding to `/network`
- add consistent top padding on careers pages

## Testing
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6882b098e148832f89002a78befc4be9