### PR TITLE
Implement Airtable submission for careers form

### DIFF
--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../../../layouts/BaseLayout.astro";
 import { getJobs } from "../../../../lib/jobs";
+import { submitToAirtable } from "../../../../lib/submitApplication";
 
 export async function getStaticPaths() {
   const jobs = await getJobs();
@@ -18,6 +19,21 @@ try {
   formData = await Astro.request.formData();
 } catch {
   formData = new FormData(); // fallback if nothing is posted
+}
+
+// Convert form data to a plain object and submit to Airtable when posted
+if (Astro.request.method === "POST" && formData) {
+  const applicant: Record<string, any> = {};
+  for (const [key, value] of formData.entries()) {
+    applicant[key] = value;
+  }
+  applicant.jobTitle = job.title;
+
+  try {
+    await submitToAirtable(applicant);
+  } catch (err) {
+    console.error("Application submission failed:", err);
+  }
 }
 ---
 


### PR DESCRIPTION
## Summary
- add Airtable helper import in careers confirmation page
- send posted application data to Airtable during confirmation

## Testing
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6883e73a5cc8832fad7c11944dec8090