### PR TITLE
Add Airtable contact form submission

### DIFF
--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -108,7 +108,6 @@ export interface ContactFields extends FieldSet {
   Email: string;
   Phone: string;
   Message: string;
-  'Submitted at': string;
 }
 
 function contactTable(): Table<ContactFields> {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -15,7 +15,6 @@ if (Astro.request.method === "POST") {
       Email: get("email"),
       Phone: get("phone"),
       Message: get("message"),
-      "Submitted at": new Date().toISOString(),
     };
 
     await createContact(data);


### PR DESCRIPTION
## Summary
- create Airtable `createContact` helper
- post contact form data to Airtable and disable prerendering
- add field names and POST behaviour on contact form
- submit form via fetch so we can show toast after the server POST

## Testing
- `npm install`
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_68876975e578832fa96738634ab73aff