### PR TITLE
Add scrolling partner logo ticker on network page

### DIFF
--- a/src/components/LogoTicker.tsx
+++ b/src/components/LogoTicker.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+// Import all images from public/Ticker
+const modules = import.meta.glob("/public/Ticker/*", { eager: true, as: "url" });
+const logos = Object.entries(modules).map(([path, url]) => {
+  const parts = path.split("/");
+  const filename = parts[parts.length - 1];
+  const alt = filename.replace(/\.[^/.]+$/, "").replace(/[-_]/g, " ");
+  return { src: url as string, alt };
+});
+
+const duplicated = [...logos, ...logos];
+
+export default function LogoTicker() {
+  return (
+    <div className="overflow-hidden py-6 bg-white">
+      <div
+        className="flex items-center gap-8 animate-scroll whitespace-nowrap hover:[animation-play-state:paused]"
+      >
+        {duplicated.map((logo, idx) => (
+          <img
+            key={idx}
+            src={logo.src}
+            alt={logo.alt}
+            loading="lazy"
+            width={80}
+            height={80}
+            className="w-16 h-16 sm:w-20 sm:h-20 object-contain"
+          />
+        ))}
+      </div>
+      <style>{`
+        @keyframes scroll {
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
+        }
+        .animate-scroll {
+          animation: scroll 30s linear infinite;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/pages/network.astro
+++ b/src/pages/network.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/BaseLayout.astro';
 import NetworkMap from '../components/NetworkMap.tsx';
+import LogoTicker from '../components/LogoTicker.tsx';
 import { fetchLocations } from '../lib/airtable';
 
 const locations = await fetchLocations();
@@ -17,6 +18,7 @@ const locations = await fetchLocations();
   <section class="min-h-screen px-4 pt-32 pb-20">
     <h1 class="text-3xl font-bold text-center mb-8">Global Network Map</h1>
     <NetworkMap locations={locations} client:only="react" />
+    <LogoTicker />
   </section>
   
 </Layout>


### PR DESCRIPTION
## Summary
- create `LogoTicker` component that loads all logos from `public/Ticker`
- animate the ticker so logos slide continuously and pause on hover
- include ticker in `/network` page below the map

## Testing
- `npm install`
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6887b96fc3f4832f9fa5acd4e6d1e319