### PR TITLE
Add Mailgun helper and use in forms

### DIFF
--- a/src/lib/mailgunClient.ts
+++ b/src/lib/mailgunClient.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import formData from 'form-data';
+import Mailgun from 'mailgun.js';
+
+// Initialize Mailgun client using API key from env
+const mailgun = new Mailgun(formData);
+const mgClient = mailgun.client({ username: 'api', key: process.env.MG_API_KEY! });
+
+// Options for sendMail helper
+export interface MailOptions {
+  from?: string;
+  to: string | string[];
+  cc?: string | string[];
+  bcc?: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+}
+
+// Helper to send email via Mailgun
+export async function sendMail(opts: MailOptions) {
+  if (!process.env.MG_DOMAIN) throw new Error('MG_DOMAIN is missing');
+  const from = opts.from ?? process.env.MAIL_FROM!;
+  return mgClient.messages.create(process.env.MG_DOMAIN, { ...opts, from });
+}

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -6,6 +6,8 @@ import Layout from "../../../../layouts/BaseLayout.astro";
 import { getJobs } from "../../../../lib/jobs";
 import { uploadResumeToCloudinary } from "../../../../lib/uploadResumeToCloudinary";
 import { base, APPLICATIONS_TABLE } from "../../../../lib/airtable";
+import { applicantConfirmation, hrNotification } from "../../../../lib/emailTemplates";
+import { sendMail } from "../../../../lib/mailgunClient";
 
 // Load job by slug
 const jobs = await getJobs();
@@ -94,6 +96,52 @@ if (!resumeUrl && resumeFile && resumeFile.size > 0) {
   resumeUrl = await uploadResumeToCloudinary(resumeFile, jobId, applicationId);
 
   console.log("✅ Resume uploaded:", resumeUrl);
+}
+
+// Step 3: Prepare and send confirmation emails
+const applicantPayload = applicantConfirmation({
+  firstName: get("firstName"),
+  role: job.title,
+});
+
+const hrPayload = hrNotification({
+  applicationId,
+  jobId: job.jobId,
+  firstName: get("firstName"),
+  lastName: get("lastName"),
+  email: get("email"),
+  countryCode: get("countryCode"),
+  phone: get("phone"),
+  nationality: get("nationality"),
+  gender,
+  dob,
+  visa: get("visa"),
+  experience,
+  linkedin: get("linkedin"),
+  about: get("about"),
+  resumeUrl,
+  role: job.title,
+});
+
+try {
+  await sendMail({
+    to: formData.get("email") as string,
+    subject: applicantPayload.subject,
+    html: applicantPayload.html,
+  });
+} catch (err) {
+  console.error("Failed to send applicant email:", err);
+}
+
+try {
+  await sendMail({
+    to: process.env.MAIL_HR!,
+    bcc: process.env.MAIL_CONTACT!,
+    subject: hrPayload.subject,
+    html: hrPayload.html,
+  });
+} catch (err) {
+  console.error("Failed to send HR notification:", err);
 }
 
 // You can add a redirect or render confirmation here

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,6 +4,8 @@ export const prerender = false;
 
 import Layout from "../layouts/BaseLayout.astro";
 import { createContact } from "../lib/airtable";
+import { contactAcknowledgement, contactNotification } from "../lib/emailTemplates";
+import { sendMail } from "../lib/mailgunClient";
 
 if (Astro.request.method === "POST") {
   try {
@@ -18,6 +20,39 @@ if (Astro.request.method === "POST") {
     };
 
     await createContact(data);
+
+    const contactData = {
+      name: get("name"),
+      company: get("company"),
+      email: get("email"),
+      phone: get("phone"),
+      message: get("message"),
+      submittedAt: new Date().toISOString(),
+    };
+
+    const contactAck = contactAcknowledgement({ name: contactData.name });
+    const contactNotif = contactNotification(contactData);
+
+    try {
+      await sendMail({
+        to: contactData.email,
+        subject: contactAck.subject,
+        html: contactAck.html,
+      });
+    } catch (err) {
+      console.error("Failed to send contact acknowledgement:", err);
+    }
+
+    try {
+      await sendMail({
+        to: process.env.MAIL_CONTACT!,
+        subject: contactNotif.subject,
+        html: contactNotif.html,
+      });
+    } catch (err) {
+      console.error("Failed to send contact notification:", err);
+    }
+
     return new Response(null, { status: 200 });
   } catch (err) {
     console.error("Failed to submit contact form:", err);


### PR DESCRIPTION
## Summary
- create `src/lib/mailgunClient.ts` with `sendMail` helper
- send confirmation and HR emails from job application confirmation page
- send acknowledgement and notification emails from contact form

## Testing
- `npm install`
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6887dbe5b624832f8c6cf2c518b4e358