### PR TITLE
Add reCAPTCHA to job application form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ MAIL_FROM="GC International <noreply@domain.com>"
 MAIL_HR="hr@domain.com"
 MAIL_CONTACT="contact@domain.com"
 
+# Google reCAPTCHA v2
+RECAPTCHA_SITE_KEY=your_site_key_here
+RECAPTCHA_SECRET_KEY=your_secret_key_here
+
 
 #Cloudinary (Resume Storage) 
 CLOUDINARY_URL=cloudinary://<API_KEY>:<API_SECRET>@<CLOUD_NAME>

--- a/api/verifyRecaptcha.ts
+++ b/api/verifyRecaptcha.ts
@@ -1,0 +1,37 @@
+import "dotenv/config";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ success: false });
+    return;
+  }
+
+  const token = (req.body as any)?.token;
+
+  if (typeof token !== "string" || !token) {
+    res.status(400).json({ success: false });
+    return;
+  }
+
+  try {
+    const params = new URLSearchParams();
+    params.append("secret", process.env.RECAPTCHA_SECRET_KEY || "");
+    params.append("response", token);
+
+    const response = await fetch(
+      "https://www.google.com/recaptcha/api/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+      }
+    );
+
+    const data = await response.json();
+    res.status(200).json({ success: !!data.success });
+  } catch (err) {
+    console.error("reCAPTCHA verify error:", err);
+    res.status(500).json({ success: false });
+  }
+}

--- a/src/components/RecaptchaCheckbox.tsx
+++ b/src/components/RecaptchaCheckbox.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react";
+
+declare global {
+  interface Window {
+    recaptchaRef?: { getToken: () => Promise<string> };
+    grecaptcha: any;
+  }
+}
+
+export default function RecaptchaCheckbox() {
+  const widgetIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (window.grecaptcha) {
+      init();
+    } else {
+      const script = document.createElement("script");
+      script.src = "https://www.google.com/recaptcha/api.js?render=explicit";
+      script.async = true;
+      script.onload = init;
+      document.body.appendChild(script);
+    }
+
+    function init() {
+      widgetIdRef.current = window.grecaptcha.render("recaptcha-container", {
+        sitekey: import.meta.env.RECAPTCHA_SITE_KEY,
+        theme: "light",
+      });
+
+      window.recaptchaRef = {
+        getToken: () => {
+          return new Promise<string>((resolve) => {
+            const id = widgetIdRef.current!;
+            window.grecaptcha.execute(id);
+            const check = () => {
+              const token = window.grecaptcha.getResponse(id);
+              if (token) {
+                resolve(token);
+              } else {
+                setTimeout(check, 300);
+              }
+            };
+            check();
+          });
+        },
+      };
+    }
+  }, []);
+
+  return <div id="recaptcha-container"></div>;
+}

--- a/src/pages/careers/apply/[slug]/index.astro
+++ b/src/pages/careers/apply/[slug]/index.astro
@@ -5,6 +5,7 @@ import Layout from "../../../../layouts/BaseLayout.astro";
 import { getJobs, type Job } from "../../../../lib/jobs";
 import { getCountryList } from "../../../../lib/getCountryData";
 import type { Country } from "../../../../lib/getCountryData";
+import RecaptchaCheckbox from "../../../../components/RecaptchaCheckbox";
 
 // Static paths
 export async function getStaticPaths() {
@@ -42,6 +43,7 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
     <h1 class="text-3xl font-bold mb-4">Apply for {job.title}</h1>
 
     <form
+      id="applicationForm"
       method="POST"
       enctype="multipart/form-data"
       action={`/careers/apply/${slug}/review`}
@@ -140,7 +142,10 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
 
       <div class="pt-6 flex justify-between">
         <a href={`/careers/${job.slug}`} class="bg-[#ed1c24] hover:bg-red-600 text-white px-6 py-2 rounded text-sm font-medium">Back to Job</a>
-        <button type="submit" class="bg-[#0054a4] hover:bg-blue-700 text-white px-6 py-2 rounded text-sm font-medium">Review Application</button>
+        <div class="flex flex-col items-end space-y-4">
+          <RecaptchaCheckbox client:load />
+          <button id="applyBtn" type="submit" class="bg-[#0054a4] hover:bg-blue-700 text-white px-6 py-2 rounded text-sm font-medium">Review Application</button>
+        </div>
       </div>
     </form>
   </section>
@@ -157,13 +162,32 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
         });
       }
 
-      document.querySelector("form")?.addEventListener("submit", (e) => {
+      document.getElementById("applyBtn")?.addEventListener("click", async (e) => {
+        e.preventDefault();
         const fileInput = document.getElementById("resumeInput");
-        if (!(fileInput instanceof HTMLInputElement)) return;
-        const file = fileInput.files?.[0];
-        if (file && file.size > 1048576) {
-          e.preventDefault();
-          alert("Resume must be under 1 MB.");
+        if (fileInput instanceof HTMLInputElement) {
+          const file = fileInput.files?.[0];
+          if (file && file.size > 1048576) {
+            alert("Resume must be under 1 MB.");
+            return;
+          }
+        }
+
+        try {
+          const token = await window.recaptchaRef?.getToken();
+          const resp = await fetch("/api/verifyRecaptcha", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token }),
+          });
+          const { success } = await resp.json();
+          if (!success) {
+            alert("Recaptcha failed—please try again.");
+            return;
+          }
+          document.getElementById("applicationForm")?.submit();
+        } catch (err) {
+          alert("Recaptcha failed—please try again.");
         }
       });
     });


### PR DESCRIPTION
## Summary
- add sample RECAPTCHA keys to `.env.example`
- create `<RecaptchaCheckbox>` React component
- integrate checkbox into job-application form
- verify token via `/api/verifyRecaptcha` serverless function

## Testing
- `npm install`
- `npm run build` *(fails: NoAdapterInstalled)*

------
https://chatgpt.com/codex/tasks/task_e_6887dfeb7ad4832fa9a6b26387cfbf82