### PR TITLE
UI tweaks for hero, sections and forms

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,28 +1,41 @@
 import ValveViewer from "./ValveViewer";
+import AnimateIn from "./AnimateIn"; // fade-in & slide-up helper
 
 export default function Hero() {
   return (
-    <section className="bg-[#1E293B] text-white min-h-[90vh] px-6 md:px-12 flex items-center">
+    <section
+      className="bg-[#1E293B] text-white min-h-[90vh] px-6 md:px-12 py-16 lg:py-32 flex items-center"
+    >
       <div className="max-w-7xl mx-auto grid md:grid-cols-2 gap-12 items-center w-full">
         {/* Left: Text Content */}
-        <div>
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 leading-tight text-white">
-            Seamless Innovation in Pipeline Solutions
-          </h1>
-          <p className="text-base md:text-lg text-gray-300 mb-6 leading-relaxed max-w-xl">
-            GC International delivers high-performance valve, flange, and flow
-            control systems to industrial sectors across the Middle East and
-            beyond.
-          </p>
-          <div className="flex gap-4 flex-wrap">
-            <a
-              href="/contact"
-              className="bg-[#ED1C24] hover:bg-[#C70E15] text-white px-6 py-3 rounded-full font-medium shadow transition"
-            >
-              Get in Touch
-            </a>
+        <AnimateIn>
+          <div className="text-center">
+            <h1 className="text-5xl lg:text-6xl font-bold mb-4 leading-tight">
+              Seamless Innovation in Pipeline Solutions
+            </h1>
+            <p className="text-base md:text-lg text-gray-300 mb-6 leading-relaxed max-w-xl mx-auto">
+              GC International delivers high-performance valve, flange, and flow
+              control systems to industrial sectors across the Middle East and
+              beyond.
+            </p>
+            <div className="flex gap-4 flex-wrap justify-center">
+              {/* Primary CTA */}
+              <a
+                href="/contact"
+                className="bg-[#ed1c24] hover:bg-red-600 text-white px-8 py-4 rounded-lg transition"
+              >
+                Get Started
+              </a>
+              {/* Secondary CTA */}
+              <a
+                href="#why"
+                className="border border-[#ed1c24] text-[#ed1c24] px-8 py-4 rounded-lg hover:bg-[#ed1c24] hover:text-white transition"
+              >
+                Learn More
+              </a>
+            </div>
           </div>
-        </div>
+        </AnimateIn>
 
         {/* Right: Valve Model */}
         <div className="hidden md:flex justify-center items-center">

--- a/src/components/LogoTicker.tsx
+++ b/src/components/LogoTicker.tsx
@@ -11,8 +11,8 @@ const duplicated = [...logos, ...logos];
 
 export default function LogoTicker({ className = "" }: { className?: string }) {
   return (
-    <div className={`pt-16 pb-8 bg-white overflow-hidden ${className}`}>
-      <div className="flex items-center gap-12 sm:gap-16 md:gap-20 lg:gap-24 animate-scroll whitespace-nowrap hover:pause-on-hover">
+    <div className={`pt-16 pb-8 bg-white overflow-hidden group ${className}`}>
+      <div className="flex items-center gap-8 md:gap-12 animate-scroll whitespace-nowrap group-hover:[animation-play-state:paused]">
         {duplicated.map((logo, idx) => (
           <img
             key={idx}
@@ -22,9 +22,7 @@ export default function LogoTicker({ className = "" }: { className?: string }) {
             className="
               w-16 h-16
               sm:w-20 sm:h-20
-              md:w-24 md:h-24
-              lg:w-28 lg:h-28
-              xl:w-32 xl:h-32
+              lg:w-24 lg:h-24
               object-contain
             "
           />
@@ -36,10 +34,7 @@ export default function LogoTicker({ className = "" }: { className?: string }) {
           100% { transform: translateX(-50%); }
         }
         .animate-scroll {
-          animation: scroll 40s linear infinite;
-        }
-        .pause-on-hover:hover {
-          animation-play-state: paused !important;
+          animation: scroll 60s linear infinite;
         }
       `}</style>
     </div>

--- a/src/components/PartnersSection.tsx
+++ b/src/components/PartnersSection.tsx
@@ -67,7 +67,7 @@ export default function PartnersSection() {
         </h2>
 
         {/* Main partner grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-y-24 gap-x-24 justify-items-center">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 lg:gap-8">
           {partners.map((partner, idx) => (
           <a
             key={idx}
@@ -77,13 +77,15 @@ export default function PartnersSection() {
             className="group flex flex-col items-center text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-md"
             aria-label={`${partner.name} – ${partner.title}`}
           >
-            <img
-              src={partner.image}
-              alt={partner.name}
-              loading="lazy"
-              className="h-32 mb-3 object-contain transition-transform duration-200 group-hover:scale-105"
-            />
-            <h3 className="text-base font-semibold text-gray-800">
+            <div className="flex items-center justify-center p-4 bg-white rounded shadow-sm hover:shadow-md">
+              <img
+                src={partner.image}
+                alt={partner.name}
+                loading="lazy"
+                className="h-32 object-contain transition-transform duration-200 group-hover:scale-105"
+              />
+            </div>
+            <h3 className="text-base font-semibold text-gray-800 mt-3">
               {partner.name}
             </h3>
             <p className="text-sm text-gray-500">{partner.title}</p>
@@ -100,13 +102,15 @@ export default function PartnersSection() {
             className="group flex flex-col items-center text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 rounded-md"
             aria-label={`${lastPartner.name} – ${lastPartner.title}`}
           >
-            <img
-              src={lastPartner.image}
-              alt={lastPartner.name}
-              loading="lazy"
-              className="h-32 mb-3 object-contain transition-transform duration-200 group-hover:scale-105"
-            />
-            <h3 className="text-base font-semibold text-gray-800">
+            <div className="flex items-center justify-center p-4 bg-white rounded shadow-sm hover:shadow-md">
+              <img
+                src={lastPartner.image}
+                alt={lastPartner.name}
+                loading="lazy"
+                className="h-32 object-contain transition-transform duration-200 group-hover:scale-105"
+              />
+            </div>
+            <h3 className="text-base font-semibold text-gray-800 mt-3">
               {lastPartner.name}
             </h3>
             <p className="text-sm text-gray-500">{lastPartner.title}</p>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -62,7 +62,7 @@ export default function StatsSection() {
 
         <div
           ref={containerRef}
-          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 lg:gap-12"
         >
           {metrics.map((stat, i) => (
             <div
@@ -71,7 +71,7 @@ export default function StatsSection() {
             >
               <div className="flex items-baseline">
                 <span
-                  className="counter text-4xl sm:text-5xl font-bold text-[#ed1c24]"
+                  className="counter text-5xl md:text-6xl font-bold text-[#ed1c24]"
                   data-end={stat.value}
                 >
                   0
@@ -82,7 +82,7 @@ export default function StatsSection() {
                   </span>
                 )}
               </div>
-              <h3 className="mt-4 text-lg sm:text-xl font-semibold text-[#0054a4] text-center">
+              <h3 className="mt-4 text-lg sm:text-xl font-semibold text-[#ed1c24] text-center">
                 {stat.title}
               </h3>
             </div>

--- a/src/components/WhyChooseUs.tsx
+++ b/src/components/WhyChooseUs.tsx
@@ -2,20 +2,14 @@ export default function WhyChooseUs() {
   return (
     <section
       id="why"
-      className="
-        w-full
-        px-6 sm:px-8 md:px-12
-        pt-12 sm:pt-16 md:pt-20 lg:pt-24
-        pb-16 sm:pb-20 md:pb-24 lg:pb-28
-        bg-[#f3f6f9] text-gray-800
-      "
+      className="w-full px-6 sm:px-8 md:px-12 py-12 md:py-20 lg:py-32 bg-[#f3f6f9] text-gray-800"
     >
       <div className="max-w-6xl mx-auto">
         {/* Title & intro */}
         <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-6 sm:mb-8 md:mb-10 text-gray-900">
           Why Choose GC International
         </h2>
-        <p className="text-sm sm:text-base md:text-lg mb-12 sm:mb-16 md:mb-20 leading-relaxed text-gray-600 max-w-3xl">
+        <p className="text-sm md:text-base mb-12 md:mb-20 leading-relaxed text-gray-600 max-w-3xl">
           We deliver reliability and excellence through global partnerships,
           certified quality, and fast execution. Our solutions are tailored to
           meet industrial challenges across the Middle East and beyond.
@@ -57,23 +51,20 @@ export default function WhyChooseUs() {
           ].map((card, i) => (
             <div
               key={i}
-              className="bg-white rounded-xl shadow-sm p-6 sm:p-8 border border-gray-200 hover:shadow-md transition"
+              className="bg-white rounded-xl shadow-sm p-6 sm:p-8 border border-gray-200 hover:shadow-md hover:scale-105 transition-transform duration-300"
             >
               <div className="flex items-center gap-3 mb-3 sm:gap-4 sm:mb-4">
                 <img
                   src={card.icon}
                   alt={card.title + " Icon"}
-                  className="w-8 h-8 sm:w-10 sm:h-10"
+                  className="w-12 h-12 md:w-14 md:h-14"
                   loading="lazy"
                 />
-                <h3 className="font-semibold text-gray-800
-                               text-base sm:text-lg md:text-xl">
+                <h3 className="font-semibold text-gray-800 text-lg md:text-xl">
                   {card.title}
                 </h3>
               </div>
-              <p className="text-gray-600
-                            text-sm sm:text-base md:text-lg
-                            leading-relaxed">
+              <p className="text-gray-600 text-sm md:text-base leading-relaxed">
                 {card.text}
               </p>
             </div>

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -163,7 +163,12 @@ try {
   ogUrl={Astro.url.href}
 >
   <section class="pt-32 pb-12 px-4 max-w-2xl mx-auto text-center">
-    <h1 class="text-3xl font-bold mb-4">Application Submitted</h1>
+    <h1 class="text-3xl font-bold mb-4">Step 3: Application Submitted</h1>
+    <div class="flex items-center justify-between mb-8">
+      <span class="font-medium text-gray-600 opacity-50">1. Fill Details</span>
+      <span class="font-medium text-gray-600 opacity-50">2. Review</span>
+      <span class="font-medium text-gray-600">3. Submit</span>
+    </div>
     <p class="text-lg mb-4">
       Thank you for applying to <strong>{job.title}</strong> at GC International.
     </p>

--- a/src/pages/careers/apply/[slug]/index.astro
+++ b/src/pages/careers/apply/[slug]/index.astro
@@ -38,15 +38,22 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
   ogDescription={`Apply for ${job.title} at GC International.`}
   ogUrl={Astro.url.href}
 >
-  <section class="pt-32 pb-12 px-4 max-w-3xl mx-auto">
-    <h1 class="text-3xl font-bold mb-4">Apply for {job.title}</h1>
+  <section class="pt-32 pb-12 px-4">
+    <div class="max-w-3xl mx-auto space-y-8">
+      <h1 class="text-3xl font-bold">Apply for {job.title}</h1>
+      <!-- Progress bar -->
+      <div class="flex items-center justify-between mb-8">
+        <span class="font-medium text-gray-600">1. Fill Details</span>
+        <span class="font-medium text-gray-600 opacity-50">2. Review</span>
+        <span class="font-medium text-gray-600 opacity-50">3. Submit</span>
+      </div>
 
-    <form
-      method="POST"
-      enctype="multipart/form-data"
-      action={`/careers/apply/${slug}/review`}
-      class="space-y-6"
-    >
+      <form
+        method="POST"
+        enctype="multipart/form-data"
+        action={`/careers/apply/${slug}/review`}
+        class="space-y-6"
+      >
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div class="grid gap-1">
           <label for="firstName">First Name *</label>
@@ -143,6 +150,7 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
         <button type="submit" class="bg-[#0054a4] hover:bg-blue-700 text-white px-6 py-2 rounded text-sm font-medium">Review Application</button>
       </div>
     </form>
+    </div>
   </section>
 
   <script is:inline>

--- a/src/pages/careers/apply/[slug]/review.astro
+++ b/src/pages/careers/apply/[slug]/review.astro
@@ -82,10 +82,14 @@ const isPdf = resumeUrl.endsWith(".pdf");
   ogUrl={Astro.url.href}
 >
   <section class="pt-32 pb-12 px-4 max-w-3xl mx-auto">
-    <h1 class="text-3xl font-bold mb-6">
-      Review Your Application for <span class="text-blue-800">{job.title}</span>
-    </h1>
+    <h1 class="text-3xl font-bold mb-6">Step 2: Review Your Application</h1>
+    <div class="flex items-center justify-between mb-8">
+      <span class="font-medium text-gray-600 opacity-50">1. Fill Details</span>
+      <span class="font-medium text-gray-600">2. Review</span>
+      <span class="font-medium text-gray-600 opacity-50">3. Submit</span>
+    </div>
 
+    <div class="bg-white p-6 rounded-lg shadow">
     <ul class="space-y-3 text-lg">
       <li><strong>First Name:</strong> {values.firstName}</li>
       <li><strong>Last Name:</strong> {values.lastName}</li>
@@ -99,6 +103,7 @@ const isPdf = resumeUrl.endsWith(".pdf");
       <li><strong>LinkedIn:</strong> {values.linkedin}</li>
       <li><strong>About:</strong> {values.about}</li>
     </ul>
+    </div>
 
     {isPdf && (
       <div class="mt-10">
@@ -138,7 +143,7 @@ const isPdf = resumeUrl.endsWith(".pdf");
 
       <button
         type="submit"
-        class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded mt-4"
+        class="bg-[#ed1c24] hover:bg-red-600 text-white px-8 py-4 rounded-lg mt-4"
       >
         Submit Application
       </button>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -80,29 +80,30 @@ if (Astro.request.method === "POST") {
 >
   <!-- push content below the fixed navbar -->
   <section class="min-h-screen bg-[#f9f9f9] pt-48 pb-20 px-4 text-gray-800">
-    <div class="max-w-6xl mx-auto bg-white rounded-lg shadow-md grid md:grid-cols-2 gap-12 p-10">
+    <div class="max-w-6xl mx-auto text-center">
+      <div class="bg-white rounded-lg shadow-md grid md:grid-cols-2 gap-12 p-10">
 
       <!-- LEFT: heading / logo / blurb / office info -->
       <div class="flex flex-col h-full">
 
         <!-- Heading, Logo & Blurb spaced out -->
-        <div class="flex flex-col items-center text-center space-y-16">
-          <h1 class="text-4xl font-bold text-[#0054a4]">Contact Us</h1>
+        <div class="flex flex-col items-center space-y-4 mb-12">
+          <h1 class="text-4xl font-bold text-[#ed1c24]">Contact Us</h1>
           <img
             src="/GC Logo.png"
             alt="GC International Logo"
-            class="w-80"
+            class="w-56 h-auto"
           />
-          <p class="text-gray-600 max-w-sm">
-            We would love to hear from you. Fill out the form and our team will be in touch shortly.
-          </p>
         </div>
+        <p class="text-gray-600 max-w-sm mx-auto">
+          We would love to hear from you. Fill out the form and our team will be in touch shortly.
+        </p>
 
         <!-- push office info to bottom -->
         <div class="flex-1"></div>
 
         <!-- Centered Head Office block -->
-        <div class="text-sm text-gray-700 leading-relaxed text-center mt-10 space-y-1">
+        <div class="mt-auto text-center text-sm text-gray-700 leading-relaxed space-y-1">
           <div><strong>Head Office – Dubai</strong></div>
           <div>GC International FZE</div>
           <div>Dubai Airport Freezone</div>
@@ -115,58 +116,58 @@ if (Astro.request.method === "POST") {
 
       <!-- RIGHT: Contact Form (unchanged) -->
       <div>
-        <form id="contactForm" method="POST" class="grid gap-6" novalidate>
+        <form id="contactForm" method="POST" class="grid gap-6 sm:gap-8 md:gap-12" novalidate>
           <!-- Name -->
           <div class="grid gap-2">
-            <label for="name" class="font-medium">Name</label>
+            <label for="name" class="block font-medium mb-1">Name</label>
             <input
               id="name"
               name="name"
               type="text"
               placeholder="Your full name"
               required
-              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0054a4]"
+              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#ed1c24] placeholder-gray-400"
             />
           </div>
           <!-- Company -->
           <div class="grid gap-2">
-            <label for="company" class="font-medium">Company</label>
+            <label for="company" class="block font-medium mb-1">Company</label>
             <input
               id="company"
               name="company"
               type="text"
               placeholder="Company name"
               required
-              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0054a4]"
+              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#ed1c24] placeholder-gray-400"
             />
           </div>
           <!-- Email -->
           <div class="grid gap-2">
-            <label for="email" class="font-medium">Email</label>
+            <label for="email" class="block font-medium mb-1">Email</label>
             <input
               id="email"
               name="email"
               type="email"
               placeholder="you@example.com"
               required
-              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0054a4]"
+              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#ed1c24] placeholder-gray-400"
             />
           </div>
           <!-- Phone -->
           <div class="grid gap-2">
-            <label for="phone" class="font-medium">Phone</label>
+            <label for="phone" class="block font-medium mb-1">Phone</label>
             <input
               id="phone"
               name="phone"
               type="tel"
               placeholder="+971 50 123 4567"
               required
-              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0054a4]"
+              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#ed1c24] placeholder-gray-400"
             />
           </div>
           <!-- Message + Counter -->
-          <div class="grid gap-2 relative">
-            <label for="message" class="font-medium">Message</label>
+          <div class="grid gap-2">
+            <label for="message" class="block font-medium mb-1">Message</label>
             <textarea
               id="message"
               name="message"
@@ -174,11 +175,9 @@ if (Astro.request.method === "POST") {
               placeholder="Type your message here..."
               required
               maxlength="500"
-              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0054a4]"
+              class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#ed1c24] placeholder-gray-400"
             ></textarea>
-            <div id="charCount" class="absolute bottom-2 right-3 text-xs text-gray-500">
-              0 / 500
-            </div>
+            <div id="charCount" class="text-right text-xs text-gray-500 mt-1">0 / 500</div>
           </div>
           <!-- Submit -->
           <button
@@ -195,6 +194,7 @@ if (Astro.request.method === "POST") {
           class="hidden fixed bottom-5 right-5 bg-green-600 text-white py-2 px-4 rounded shadow"
         ></div>
       </div>
+    </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- enlarge hero heading and add dual CTAs with fade-in
- tighten WhyChooseUs layout and hover effects
- update Stats, Partners and LogoTicker styles
- implement 3‑step careers application flow
- polish contact page layout and form styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a92d9dbac832fa6a22a5bb3c89ce9