### PR TITLE
Add career application progress steps

### DIFF
--- a/src/components/ProgressSteps.astro
+++ b/src/components/ProgressSteps.astro
@@ -1,0 +1,50 @@
+---
+const { currentStep = 1 } = Astro.props;
+const steps = [
+  { label: 'Application', key: 1 },
+  { label: 'Review', key: 2 },
+  { label: 'Confirmation', key: 3 }
+];
+const stepIndex =
+  typeof currentStep === 'number'
+    ? currentStep - 1
+    : steps.findIndex((s) =>
+        s.label.toLowerCase() === String(currentStep).toLowerCase()
+      );
+---
+<nav aria-label="Application progress" class="w-full max-w-3xl mx-auto mt-6">
+  <ol class="flex items-center justify-between">
+    {steps.map((step, idx) => (
+      <li class="flex-1 flex items-center" aria-current={idx === stepIndex ? 'step' : undefined}>
+        <div
+          class={`flex items-center justify-center w-8 h-8 rounded-full text-white text-sm font-semibold ${idx <= stepIndex ? 'bg-[#e41f26]' : 'bg-[#003b71]'}`}
+        >
+          {idx < stepIndex ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M16.704 5.29a1 1 0 00-1.408-1.418l-6.692 6.648-2.9-2.898a1 1 0 00-1.416 1.414l3.6 3.6a1 1 0 001.416 0l7.4-7.346z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          ) : (
+            idx + 1
+          )}
+        </div>
+        {idx < steps.length - 1 && (
+          <div class={`flex-1 h-0.5 sm:h-1 ${idx < stepIndex ? 'bg-[#e41f26]' : 'bg-[#003b71]'}`}></div>
+        )}
+      </li>
+    ))}
+  </ol>
+  <ol class="mt-2 flex justify-between text-xs sm:text-sm font-medium">
+    {steps.map((step) => (
+      <li class="flex-1 text-center">{step.label}</li>
+    ))}
+  </ol>
+</nav>

--- a/src/components/ProgressSteps.astro
+++ b/src/components/ProgressSteps.astro
@@ -13,12 +13,16 @@ const stepIndex =
       );
 ---
 <nav aria-label="Application progress" class="w-full max-w-3xl mx-auto mt-6">
-  <ol class="flex items-center justify-between">
+  <ol class="flex flex-col sm:flex-row items-start sm:items-center">
     {steps.map((step, idx) => (
-      <li class="flex-1 flex items-center" aria-current={idx === stepIndex ? 'step' : undefined}>
+      <li
+        class="flex items-center sm:flex-1"
+        aria-current={idx === stepIndex ? 'step' : undefined}
+      >
         <div
           class={`flex items-center justify-center w-8 h-8 rounded-full text-white text-sm font-semibold ${idx <= stepIndex ? 'bg-[#e41f26]' : 'bg-[#003b71]'}`}
         >
+          <span class="sr-only">Step {idx + 1}</span>
           {idx < stepIndex ? (
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -37,12 +41,14 @@ const stepIndex =
           )}
         </div>
         {idx < steps.length - 1 && (
-          <div class={`flex-1 h-0.5 sm:h-1 ${idx < stepIndex ? 'bg-[#e41f26]' : 'bg-[#003b71]'}`}></div>
+          <div
+            class={`sm:flex-1 sm:h-1 h-6 w-px sm:w-auto ${idx < stepIndex ? 'bg-[#e41f26]' : 'bg-[#003b71]'}`}
+          ></div>
         )}
       </li>
     ))}
   </ol>
-  <ol class="mt-2 flex justify-between text-xs sm:text-sm font-medium">
+  <ol class="mt-2 flex flex-col sm:flex-row justify-between text-xs sm:text-sm font-medium">
     {steps.map((step) => (
       <li class="flex-1 text-center">{step.label}</li>
     ))}

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -8,6 +8,7 @@ import { uploadResumeToCloudinary } from "../../../../lib/uploadResumeToCloudina
 import { base, APPLICATIONS_TABLE } from "../../../../lib/airtable";
 import { applicantConfirmation, hrNotification } from "../../../../lib/emailTemplates";
 import { sendMail } from "../../../../lib/mailgunClient";
+import ProgressSteps from "../../../../components/ProgressSteps.astro";
 
 // Load job by slug
 console.log('--- Handling job application confirmation ---');
@@ -170,6 +171,7 @@ try {
   ogDescription={`Thank you for applying to GC International.`}
   ogUrl={Astro.url.href}
 >
+  <ProgressSteps currentStep="Confirmation" />
   <section class="pt-32 pb-12 px-4 max-w-2xl mx-auto text-center">
     <h1 class="text-3xl font-bold mb-4">Application Submitted</h1>
     <p class="text-lg mb-4">

--- a/src/pages/careers/apply/[slug]/index.astro
+++ b/src/pages/careers/apply/[slug]/index.astro
@@ -5,6 +5,7 @@ import Layout from "../../../../layouts/BaseLayout.astro";
 import { getJobs, type Job } from "../../../../lib/jobs";
 import { getCountryList } from "../../../../lib/getCountryData";
 import type { Country } from "../../../../lib/getCountryData";
+import ProgressSteps from "../../../../components/ProgressSteps.astro";
 
 // Static paths
 export async function getStaticPaths() {
@@ -38,6 +39,7 @@ const countryCodes: Country[] = (await getCountryList()).sort((a, b) =>
   ogDescription={`Apply for ${job.title} at GC International.`}
   ogUrl={Astro.url.href}
 >
+  <ProgressSteps currentStep="Application" />
   <section class="pt-32 pb-12 px-4 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-4">Apply for {job.title}</h1>
 

--- a/src/pages/careers/apply/[slug]/review.astro
+++ b/src/pages/careers/apply/[slug]/review.astro
@@ -3,6 +3,7 @@ export const prerender = false;
 
 import Layout from "../../../../layouts/BaseLayout.astro";
 import { getJobs, type Job } from "../../../../lib/jobs";
+import ProgressSteps from "../../../../components/ProgressSteps.astro";
 
 // Static paths
 export async function getStaticPaths() {
@@ -79,6 +80,7 @@ const isPdf = values.resumeMime === "application/pdf";
   ogDescription={`Review your application for ${job.title}.`}
   ogUrl={Astro.url.href}
 >
+  <ProgressSteps currentStep="Review" />
   <section class="pt-24 md:pt-32 pb-12 px-4 bg-gray-50 min-h-screen">
     <div class="max-w-4xl mx-auto">
       <div class="text-center mb-8 md:mb-10">


### PR DESCRIPTION
## Summary
- create `ProgressSteps` component for application flow
- display progress steps in application, review, and confirmation pages

## Testing
- `npm run build` *(fails: Failed to call getStaticPaths)*

------
https://chatgpt.com/codex/tasks/task_e_688ca6ec0c84832f9447b66957da814a