### PR TITLE
Add reCAPTCHA token verification to job application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ MAIL_FROM="GC International <noreply@domain.com>"
 MAIL_HR="hr@domain.com"
 MAIL_CONTACT="contact@domain.com"
 
-# reCAPTCHA
+# reCAPTCHA v2 Checkbox
 PUBLIC_RECAPTCHA_SITE_KEY=YOUR_PUBLIC_SITE_KEY_HERE
 RECAPTCHA_SECRET_KEY=YOUR_SECRET_KEY_HERE
 

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ MAIL_FROM="GC International <noreply@domain.com>"
 MAIL_HR="hr@domain.com"
 MAIL_CONTACT="contact@domain.com"
 
+# reCAPTCHA
+PUBLIC_RECAPTCHA_SITE_KEY=YOUR_PUBLIC_SITE_KEY_HERE
+RECAPTCHA_SECRET_KEY=YOUR_SECRET_KEY_HERE
+
 
 #Cloudinary (Resume Storage) 
 CLOUDINARY_URL=cloudinary://<API_KEY>:<API_SECRET>@<CLOUD_NAME>

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -28,6 +28,28 @@ try {
 
 const get = (field: string) => formData.get(field)?.toString().trim() ?? "";
 
+// Verify reCAPTCHA token
+const recaptchaToken = get("recaptchaToken");
+if (!recaptchaToken) {
+  throw new Error("Missing reCAPTCHA token");
+}
+const secretKey = process.env.RECAPTCHA_SECRET_KEY;
+if (!secretKey) {
+  console.error("RECAPTCHA_SECRET_KEY not set");
+  throw new Error("Server misconfigured");
+}
+const verifyRes = await fetch("https://www.google.com/recaptcha/api/siteverify", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/x-www-form-urlencoded",
+  },
+  body: new URLSearchParams({ secret: secretKey, response: recaptchaToken }),
+});
+const verifyJson = await verifyRes.json();
+if (!verifyJson.success) {
+  throw new Error("Invalid reCAPTCHA token");
+}
+
 const dob = get("dob");
 const gender = get("gender");
 const experience = parseFloat(get("experience"));

--- a/src/pages/careers/apply/[slug]/confirmation.astro
+++ b/src/pages/careers/apply/[slug]/confirmation.astro
@@ -28,9 +28,9 @@ try {
 
 const get = (field: string) => formData.get(field)?.toString().trim() ?? "";
 
-// Verify reCAPTCHA token
-const recaptchaToken = get("recaptchaToken");
-if (!recaptchaToken) {
+// Verify reCAPTCHA token from v2 checkbox
+const recaptchaResponse = get("g-recaptcha-response");
+if (!recaptchaResponse) {
   throw new Error("Missing reCAPTCHA token");
 }
 const secretKey = process.env.RECAPTCHA_SECRET_KEY;
@@ -43,7 +43,7 @@ const verifyRes = await fetch("https://www.google.com/recaptcha/api/siteverify",
   headers: {
     "Content-Type": "application/x-www-form-urlencoded",
   },
-  body: new URLSearchParams({ secret: secretKey, response: recaptchaToken }),
+  body: new URLSearchParams({ secret: secretKey, response: recaptchaResponse }),
 });
 const verifyJson = await verifyRes.json();
 if (!verifyJson.success) {

--- a/src/pages/careers/apply/[slug]/review.astro
+++ b/src/pages/careers/apply/[slug]/review.astro
@@ -211,13 +211,9 @@ const isPdf = values.resumeMime === "application/pdf";
             <input type="hidden" name="resumeBase64" value={values.resumeBase64} />
             <input type="hidden" name="resumeMime" value={values.resumeMime} />
             <input type="hidden" name="resumeName" value={values.resumeName} />
-            <input type="hidden" name="recaptchaToken" id="recaptchaToken" />
             <div
-              id="recaptcha-widget"
               class="g-recaptcha"
               data-sitekey={import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY}
-              data-size="invisible"
-              data-callback="onRecaptchaSuccess"
             ></div>
             
             <div class="flex flex-col-reverse sm:flex-row-reverse sm:items-center gap-4">
@@ -240,23 +236,5 @@ const isPdf = values.resumeMime === "application/pdf";
     </div>
   </section>
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-  <script is:inline>
-    document.addEventListener("DOMContentLoaded", () => {
-      const form = document.querySelector("form");
-      if (!form) return;
-      window.onRecaptchaSuccess = (token) => {
-        const input = document.getElementById("recaptchaToken");
-        if (input) input.value = token;
-        form.submit();
-      };
-      form.addEventListener("submit", (e) => {
-        e.preventDefault();
-        if (typeof grecaptcha !== "undefined") {
-          grecaptcha.execute();
-        } else {
-          form.submit();
-        }
-      });
-    });
-  </script>
 </Layout>
+

--- a/src/pages/careers/apply/[slug]/review.astro
+++ b/src/pages/careers/apply/[slug]/review.astro
@@ -211,6 +211,14 @@ const isPdf = values.resumeMime === "application/pdf";
             <input type="hidden" name="resumeBase64" value={values.resumeBase64} />
             <input type="hidden" name="resumeMime" value={values.resumeMime} />
             <input type="hidden" name="resumeName" value={values.resumeName} />
+            <input type="hidden" name="recaptchaToken" id="recaptchaToken" />
+            <div
+              id="recaptcha-widget"
+              class="g-recaptcha"
+              data-sitekey={import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY}
+              data-size="invisible"
+              data-callback="onRecaptchaSuccess"
+            ></div>
             
             <div class="flex flex-col-reverse sm:flex-row-reverse sm:items-center gap-4">
               <button
@@ -231,4 +239,24 @@ const isPdf = values.resumeMime === "application/pdf";
       </div>
     </div>
   </section>
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+  <script is:inline>
+    document.addEventListener("DOMContentLoaded", () => {
+      const form = document.querySelector("form");
+      if (!form) return;
+      window.onRecaptchaSuccess = (token) => {
+        const input = document.getElementById("recaptchaToken");
+        if (input) input.value = token;
+        form.submit();
+      };
+      form.addEventListener("submit", (e) => {
+        e.preventDefault();
+        if (typeof grecaptcha !== "undefined") {
+          grecaptcha.execute();
+        } else {
+          form.submit();
+        }
+      });
+    });
+  </script>
 </Layout>


### PR DESCRIPTION
## Summary
- include reCAPTCHA token in the job application form
- verify the token server-side before processing an application
- document required reCAPTCHA environment variables

## Testing
- `npm run build` *(fails: fetch failed during `getStaticPaths`)*

------
https://chatgpt.com/codex/tasks/task_e_688d05572b28832f8e6e98f692421849