### PR TITLE
Add MAIL_MANAGEMENT placeholder and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,11 @@ MAIL_FROM="GC International <noreply@domain.com>"
 MAIL_HR="hr@domain.com"
 MAIL_CONTACT="contact@domain.com"
 
+# BCC address for HR notifications
+MAIL_MANAGEMENT=TYPE_MANAGEMENT_EMAIL_HERE
 
-#Cloudinary (Resume Storage) 
+
+#Cloudinary (Resume Storage)
 CLOUDINARY_URL=cloudinary://<API_KEY>:<API_SECRET>@<CLOUD_NAME>
 CLOUDINARY_API_KEY=TYPE_API_KEY_HERE
 CLOUDINARY_API_SECRET=TYPE_API_SECRET_HERE

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ npm install
 # yarn install
 ```
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and provide your configuration values. `MAIL_MANAGEMENT` sets the management email address that is BCC'd on HR notifications.
+
 ## To Run
 <div align="center">
   <!-- Image 1 -->


### PR DESCRIPTION
## Summary
- add MAIL_MANAGEMENT placeholder to environment example
- document management BCC variable in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68912a239b8c832f803c15a76bb32079